### PR TITLE
Alert dialog now shows up when the QR scanner detects a non-url

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -99,6 +99,7 @@ class _QRScannerViewState extends State<QRScannerView> {
       if (dataIsURL) {
         launch(scanData.code!);
       } else {
+        showAlertDialog(context, scanData.code!, controller);
         controller.pauseCamera();
       }
     });
@@ -122,4 +123,30 @@ class _QRScannerViewState extends State<QRScannerView> {
   bool isStringURL(String message) {
     return isURL(message);
   }
+}
+
+showAlertDialog(
+    BuildContext context, String message, QRViewController controller) {
+  Widget okButton = TextButton(
+    child: Text("OK"),
+    onPressed: () async {
+      Navigator.of(context).pop();
+      await controller.resumeCamera();
+    },
+  );
+
+  AlertDialog alert = AlertDialog(
+    title: Text("Message Scanned!"),
+    content: Text(message),
+    actions: [
+      okButton,
+    ],
+  );
+
+  showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return alert;
+    },
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.10.1 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
When scanning a QR code, a check is made to see if the result is a URL or not. If it is not a URL, this alert dialog is shown with the text from the QR code inside it